### PR TITLE
Check remote credential (fixes #1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "clap",
  "keyring",
  "regex",
+ "tempfile",
 ]
 
 [[package]]
@@ -198,6 +199,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,7 +259,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -285,6 +314,12 @@ checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
 dependencies = [
  "pkg-config",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
@@ -449,7 +484,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -480,6 +515,19 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "security-framework"
@@ -544,6 +592,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom 0.3.1",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +622,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "winapi"
@@ -655,6 +726,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ anyhow = "1.0.95"
 clap = { version = "4.5.29", features = ["env", "derive"] }
 keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "sync-secret-service"] }
 regex = "1.11.1"
+tempfile = "3.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aspect-reauth"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Stairwell, Inc."]
 edition = "2021"
 description = "Sync fresh Aspect credentials with your dev VM"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This tool syncs your [Aspect][0] credentials with a remote Linux VM. It first checks whether the credentials are expired (unless `--force` is passed), and if so, runs `aspect-credential-helper login` with your configured remote. Then, it reads the credential out of your OS's keychain and stores it in your Linux VM's [keyutils][1] keychain via `ssh devbox keyctl`.
 
-Because we directly call the macOS keychain APIs ourselves, assuming you trust this program, you should be able to push "Always Allow" to prevent from having to type your password twice every time you run this. (For some reason even if you push "Always Allow", you need to type your password once per run to unlock your keychain.)
+Because we directly call the macOS keychain APIs ourselves, assuming you trust this program, you should be able to push "Always Allow" to prevent from having to type your password twice every time you run this. (For some reason even if you push "Always Allow", you still need to type your password once if this needs to sync your credential.)
 
 ## Installation
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,7 @@ impl SshMux {
         };
         let mut cmd = Command::new("ssh");
         if !reuse_socket {
+            // cf. scp.c in openssh-portable.
             cmd.args([
                 "-xMTS",
                 &ret.control_path().to_string_lossy(),


### PR DESCRIPTION
Rather than checking the local credential to decide whether to login and then unconditionally syncing the credential, we check the remote credential to decide whether to do anything at all.

Practically speaking, this obviates needing to type your password in the case where the remote credential is still valid.

To implement it, I wound up writing a small SSH multiplexer class. It will start an ssh ControlMaster with a socket in a temporary directory (unless `-r` is passed in which case it assumes you have a socket configured already) and multiplex its SSH commands over that socket to save a bit of time.