### PR TITLE
Add github workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
             suffix: ""
     steps:
+    - run: sudo sh -c 'apt update && apt install libdbus-1-dev'
+      if: matrix.os == 'ubuntu-latest'
     - uses: stairwell-inc/checkout@v4
     - run: rustup update
     - run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            suffix: ""
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            suffix: ""
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            suffix: ".exe"
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            suffix: ""
+    steps:
+    - uses: stairwell-inc/checkout@v4
+    - run: rustup update
+    - run: cargo build --release --target ${{ matrix.target }}
+    - uses: stairwell-inc/upload-artifact@v4
+      with:
+        name: aspect-reauth-${{ matrix.target }}
+        path: target/${{ matrix.target}}/release/aspect-reauth${{ matrix.suffix }}
+        retention-days: ${{ github.event_name == 'pull_request' && 7 || '' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
     - run: sudo sh -c 'apt update && apt install libdbus-1-dev'
       if: matrix.os == 'ubuntu-latest'
     - uses: stairwell-inc/checkout@v4
-    - run: rustup update
+    - run: rustup target add ${{ matrix.target }} && rustup update
     - run: cargo build --release --target ${{ matrix.target }}
     - uses: stairwell-inc/upload-artifact@v4
       with:


### PR DESCRIPTION
This gets us built artifacts per OS on which someone might use this, with repository-default retention period for pushes to main or versioned tags. The binaries are not yet signed, but this should at least get us started (and confirm that we build on all supported platforms.)

This also fixes a build error on Windows that was revealed by the workflow.