### PR TITLE
Do not make a tempdir if we don’t need it

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,7 @@ impl<'a> SshMux<'a> {
         // If we're reusing an existing socket but the host has ControlMaster=auto and no currently
         // running master, we do not want the created master to have the restrictive set of options
         // we pass to individual commands, so we still run an initial ssh to open a normal session.
-        cmd.args(["--", &ret.host, "true"])
+        cmd.args(["--", ret.host, "true"])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::inherit())
@@ -242,7 +242,7 @@ impl<'a> SshMux<'a> {
     }
 }
 
-impl<'a> Drop for SshMux<'a> {
+impl Drop for SshMux<'_> {
     fn drop(&mut self) {
         if let Err(e) = self.cleanup() {
             eprintln!("cleanup ssh: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,9 +179,7 @@ impl SshMux {
         let mut cmd = Command::new("ssh");
         if let Some(socket_dir) = &ret.socket_dir {
             // cf. scp.c in openssh-portable.
-            cmd.args([
-                "-xMTS",
-                &Self::control_path(socket_dir).to_string_lossy(),
+            cmd.arg("-xMTS").arg(Self::control_path(socket_dir)).args([
                 "-oControlPersist=yes",
                 "-oPermitLocalCommand=no",
                 "-oClearAllForwardings=yes",
@@ -205,7 +203,7 @@ impl SshMux {
     fn command(&self, command: &str) -> Command {
         let mut ret = Command::new("ssh");
         if let Some(socket_dir) = &self.socket_dir {
-            ret.args(["-S", &Self::control_path(socket_dir).to_string_lossy()]);
+            ret.arg("-S").arg(Self::control_path(socket_dir));
         }
         ret.args([
             "-xT",
@@ -230,13 +228,9 @@ impl SshMux {
             return Ok(());
         };
         Command::new("ssh")
-            .args([
-                "-S",
-                &Self::control_path(&socket_dir).to_string_lossy(),
-                "-Oexit",
-                "--",
-                &self.host,
-            ])
+            .arg("-S")
+            .arg(Self::control_path(&socket_dir))
+            .args(["-Oexit", "--", &self.host])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,8 +157,8 @@ fn main() -> Result<()> {
 }
 
 struct SshMux {
-    socket_dir: Option<TempDir>,
     host: String,
+    socket_dir: Option<TempDir>,
 }
 
 impl SshMux {
@@ -175,7 +175,7 @@ impl SshMux {
             })
             .transpose()?;
         let host = host.to_string();
-        let ret = SshMux { socket_dir, host };
+        let ret = SshMux { host, socket_dir };
         let mut cmd = Command::new("ssh");
         if let Some(socket_dir) = &ret.socket_dir {
             // cf. scp.c in openssh-portable.

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ struct Args {
     #[arg(short, long)]
     reuse_socket: bool,
 }
+
 fn main() -> Result<()> {
     let args = Args::parse();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use keyring::Entry;
 use regex::bytes::Regex;
-use tempfile::{Builder, TempDir};
+use tempfile::{self, TempDir};
 
 const DEFAULT_REMOTE: &str = "aw-remote-ext.buildremote.stairwell.io";
 const DEFAULT_HELPER: &str = "aspect-credential-helper";
@@ -165,7 +165,7 @@ impl SshMux {
     fn new(host: &str, reuse_socket: bool) -> Result<Self> {
         let socket_dir = (!reuse_socket)
             .then(|| {
-                let mut builder = Builder::new();
+                let mut builder = tempfile::Builder::new();
                 #[cfg(unix)]
                 {
                     use std::{fs::Permissions, os::unix::fs::PermissionsExt};


### PR DESCRIPTION
Makes the socket directory an Option, and uses this Option rather than a separate bool to track whether we are standing up our own master.

Also does some general code cleanup:

- Removes the need for to_string_lossy by passing the control path as a separate function call so its type needn’t match that of the other arg strings.
- Uses tempfile::Builder so we don't first create the TempDir and then change its permissions. Ordinarily this shouldn't matter, but if the user's umask is insane it will make things slightly less bad.
- Removes the control_path method in favor of storing the PathBuf on the struct.
- Elides a string copy by adding a lifetime parameter, since the host string is generally going to outlive this.