### PR TITLE
feat: experiment to auto-detect user socket to reuse

### DIFF
--- a/src/ssh_cmd.rs
+++ b/src/ssh_cmd.rs
@@ -1,0 +1,36 @@
+use anyhow::Result;
+use std::process::Command;
+
+pub fn has_user_socket(host: &str) -> Result<bool> {
+    // Get the output of `ssh -G <host>` this will have a standard
+    // lowercase represesntation of:
+    //
+    // <key> <value>
+    //
+    // so a basic match should be enough.
+    let output = Command::new("ssh").arg("-G").arg(host).output()?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "failed to check for existing control socket: {}\n\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim(),
+        );
+    }
+    let stdout = String::from_utf8(output.stdout)?;
+
+    let mut has_controlmaster_auto = false;
+    let mut has_controlpersist = false;
+
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line == "controlmaster auto" {
+            has_controlmaster_auto = true;
+        }
+        if line.starts_with("controlpersist") {
+            has_controlpersist = true;
+        }
+    }
+
+    Ok(has_controlmaster_auto && has_controlpersist)
+}


### PR DESCRIPTION
From our discussion on slack, here's a little experiment to auto-detect if the user has an existing socket defined for the given host. The idea is to avoid the need for an `-r` flag, allowing the normal failure mode to proceed.

It works by scanning the output of `ssh -G <hostname>` and looking for a `ControlMaster auto` option along with any value for `ControlPersist`. If both conditions are true, the assumption is that the user has a socket to reuse.

Note: the output of `ssh -G` appears to be deterministic from testing, so the matches can afford to be dumb.