### PR TITLE
Split out TempSocket, introduce modules

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
+
+mod ssh_mux;
+
 use std::{
     io::Write,
-    path::PathBuf,
     process::{Command, Stdio},
     thread,
 };
@@ -24,7 +25,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use keyring::Entry;
 use regex::bytes::Regex;
-use tempfile::{self, TempDir};
+use ssh_mux::SshMux;
 
 const DEFAULT_REMOTE: &str = "aw-remote-ext.buildremote.stairwell.io";
 const DEFAULT_HELPER: &str = "aspect-credential-helper";
@@ -89,9 +90,8 @@ fn main() -> Result<()> {
             })?;
         let mut stdin = child.stdin.take().context("failed to open stdin")?;
         let test_string = format!(concat!(r#"{{"uri":"https://{}"}}"#, "\n"), &args.remote);
-        thread::spawn(move || -> Result<()> {
-            stdin.write_all(test_string.as_bytes())?;
-            Ok(())
+        thread::spawn(move || {
+            let _ = stdin.write_all(test_string.as_bytes());
         });
         let output = child
             .wait_with_output()
@@ -143,11 +143,9 @@ fn main() -> Result<()> {
         .spawn()
         .with_context(|| format!("failed to run keyctl on {}", &args.host))?;
     let mut stdin = child.stdin.take().context("failed to open stdin")?;
-    thread::spawn(move || -> Result<()> {
-        stdin.write_all(credential.as_bytes())?;
-        Ok(())
+    thread::spawn(move || {
+        let _ = stdin.write_all(credential.as_bytes());
     });
-
     let output = child.wait_with_output()?;
     if !output.status.success() {
         anyhow::bail!(
@@ -157,112 +155,10 @@ fn main() -> Result<()> {
             String::from_utf8_lossy(&output.stderr).trim(),
         );
     }
+
     println!(
         "Aspect credentials synced to {}. Have a nice day.",
         args.host
     );
     Ok(())
-}
-
-struct SshMux<'a> {
-    host: &'a str,
-    socket: Option<Socket>,
-}
-
-struct Socket {
-    path: PathBuf,
-    _dir: TempDir,
-}
-
-impl<'a> SshMux<'a> {
-    fn new(host: &'a str, reuse_socket: bool) -> Result<Self> {
-        let socket = (!reuse_socket)
-            .then(|| -> Result<Socket> {
-                let mut builder = tempfile::Builder::new();
-                #[cfg(unix)]
-                {
-                    use std::{fs::Permissions, os::unix::fs::PermissionsExt};
-                    builder.permissions(Permissions::from_mode(0o700));
-                }
-                let _dir = builder.prefix("aspect-reauth-").tempdir()?;
-                let path = _dir.path().join("sock");
-                Ok(Socket { path, _dir })
-            })
-            .transpose()?;
-        let ret = SshMux { host, socket };
-        let mut cmd = Command::new("ssh");
-        if let Some(socket) = &ret.socket {
-            // cf. scp.c in openssh-portable.
-            cmd.arg("-xMTS").arg(&socket.path).args([
-                "-oControlPersist=yes",
-                "-oPermitLocalCommand=no",
-                "-oClearAllForwardings=yes",
-                "-oRemoteCommand=none",
-                "-oForwardAgent=no",
-                "-oBatchMode=yes",
-            ]);
-        }
-        // If we're reusing an existing socket but the host has ControlMaster=auto and no currently
-        // running master, we do not want the created master to have the restrictive set of options
-        // we pass to individual commands, so we still run an initial ssh to open a normal session.
-        let output = cmd
-            .args(["--", ret.host, "true"])
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .output()
-            .context("failed to start SSH control master")?;
-        if !output.status.success() {
-            anyhow::bail!(
-                "ssh {}: {}\n\n{}",
-                ret.host,
-                output.status,
-                String::from_utf8_lossy(&output.stderr).trim(),
-            );
-        }
-        Ok(ret)
-    }
-
-    fn command(&self, command: &str) -> Command {
-        let mut ret = Command::new("ssh");
-        if let Some(socket) = &self.socket {
-            ret.arg("-S").arg(&socket.path);
-        }
-        ret.args([
-            "-xT",
-            "-oPermitLocalCommand=no",
-            "-oClearAllForwardings=yes",
-            "-oRemoteCommand=none",
-            "-oForwardAgent=no",
-            "-oBatchMode=yes",
-            "--",
-            self.host,
-            command,
-        ]);
-        ret
-    }
-
-    fn cleanup(&mut self) -> Result<()> {
-        let Some(socket) = self.socket.take() else {
-            return Ok(());
-        };
-        Command::new("ssh")
-            .arg("-S")
-            .arg(&socket.path)
-            .args(["-Oexit", "--", self.host])
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .context("failed to cleanup SSH control master")?;
-        Ok(())
-    }
-}
-
-impl Drop for SshMux<'_> {
-    fn drop(&mut self) {
-        if let Err(e) = self.cleanup() {
-            eprintln!("cleanup ssh: {}", e);
-        }
-    }
 }

--- a/src/ssh_mux/mod.rs
+++ b/src/ssh_mux/mod.rs
@@ -1,0 +1,119 @@
+// Copyright 2025 Stairwell, Inc.
+// Author: mrdomino@stairwell.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod temp_socket;
+
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result};
+use temp_socket::TempSocket;
+
+/// A batched SSH command multiplexer.
+///
+/// This class does two things:
+/// 1. It passes a set of restrictive options to `ssh` suitable for use in a batch context.
+/// 2. Optionally, it stands up a temporary SSH master and control socket, allowing the same socket
+///    to be reused across SSH commands so that subsequent commands do not incur connection setup
+///    overhead.
+pub struct SshMux<'a> {
+    host: &'a str,
+    socket: Option<TempSocket>,
+}
+
+impl<'a> SshMux<'a> {
+    pub fn new(host: &'a str, reuse_socket: bool) -> Result<Self> {
+        let socket = (!reuse_socket)
+            .then(|| {
+                TempSocket::new(|builder| {
+                    builder.prefix("aspect-reauth-");
+                })
+            })
+            .transpose()?;
+        let mut cmd = Command::new("ssh");
+        if let Some(socket) = &socket {
+            // cf. scp.c in openssh-portable.
+            cmd.arg("-xMTS").arg(socket).args([
+                "-oControlPersist=yes",
+                "-oPermitLocalCommand=no",
+                "-oClearAllForwardings=yes",
+                "-oRemoteCommand=none",
+                "-oForwardAgent=no",
+                "-oBatchMode=yes",
+            ]);
+        }
+        // If we're reusing an existing socket but the host has ControlMaster=auto and no currently
+        // running master, we do not want the created master to have the restrictive set of options
+        // we pass to individual commands, so we still run an initial ssh to open a normal session.
+        let output = cmd
+            .args(["--", host, "true"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .context("failed to start SSH control master")?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "ssh {}: {}\n\n{}",
+                host,
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim(),
+            );
+        }
+        Ok(SshMux { host, socket })
+    }
+
+    pub fn command(&self, command: &str) -> Command {
+        let mut ret = Command::new("ssh");
+        if let Some(socket) = &self.socket {
+            ret.arg("-S").arg(socket);
+        }
+        ret.args([
+            "-xT",
+            "-oPermitLocalCommand=no",
+            "-oClearAllForwardings=yes",
+            "-oRemoteCommand=none",
+            "-oForwardAgent=no",
+            "-oBatchMode=yes",
+            "--",
+            self.host,
+            command,
+        ]);
+        ret
+    }
+
+    pub fn cleanup(&mut self) -> Result<()> {
+        let Some(socket) = self.socket.take() else {
+            return Ok(());
+        };
+        Command::new("ssh")
+            .arg("-S")
+            .arg(&socket)
+            .args(["-Oexit", "--", self.host])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .context("failed to cleanup SSH control master")?;
+        Ok(())
+    }
+}
+
+impl Drop for SshMux<'_> {
+    fn drop(&mut self) {
+        if let Err(e) = self.cleanup() {
+            eprintln!("cleanup ssh: {}", e);
+        }
+    }
+}

--- a/src/ssh_mux/temp_socket.rs
+++ b/src/ssh_mux/temp_socket.rs
@@ -1,0 +1,68 @@
+// Copyright 2025 Stairwell, Inc.
+// Author: mrdomino@stairwell.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{ffi::OsStr, fs::remove_dir_all, path::Path};
+
+use anyhow::Result;
+use tempfile::TempDir;
+
+/// Exposes and controls a path suitable for use as a temporary socket. The path is made available
+/// by `AsRef<OsStr>` on `&TempSocket`, so that a reference to this may be passed directly to
+/// `Command::arg`:
+/// ```
+/// let socket = TempSocket::new()?;
+/// let _ = Command::new("ssh").arg("-MS").arg(&socket);
+/// ```
+/// The temporary directory and its contents are removed by `drop`.
+pub struct TempSocket {
+    path: Box<Path>,
+}
+
+impl TempSocket {
+    pub fn new(opts: impl FnOnce(&mut tempfile::Builder)) -> Result<Self> {
+        let mut builder = tempfile::Builder::new();
+        #[cfg(unix)]
+        {
+            use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+            builder.permissions(Permissions::from_mode(0o700));
+        }
+        opts(&mut builder);
+        Ok(builder.tempdir()?.into())
+    }
+}
+
+impl From<TempDir> for TempSocket {
+    fn from(dir: TempDir) -> Self {
+        let mut path = dir.into_path();
+        path.push("sock");
+        TempSocket {
+            path: path.into_boxed_path(),
+        }
+    }
+}
+
+impl AsRef<OsStr> for &TempSocket {
+    fn as_ref(&self) -> &OsStr {
+        self.path.as_os_str()
+    }
+}
+
+impl Drop for TempSocket {
+    fn drop(&mut self) {
+        if let Some(dir) = self.path.parent() {
+            let _ = remove_dir_all(dir);
+        }
+    }
+}


### PR DESCRIPTION
TempSocket is primarily a space-saving optimization: it takes 32 bytes and a duplicate heap allocation off of Socket, and is slightly more ergonomic to use.

This also moves SshMux into its own module, and TempSocket into a module on ssh_mux.

I also added some doc comments on the two structs, and subsumed the changes from #18 and #11.