### PR TITLE
Add `--create-socket` flag

### DIFF
--- a/src/ssh_mux/mod.rs
+++ b/src/ssh_mux/mod.rs
@@ -33,8 +33,8 @@ pub struct SshMux<'a> {
 }
 
 impl<'a> SshMux<'a> {
-    pub fn new(host: &'a str, reuse_socket: bool) -> Result<Self> {
-        let socket = (!reuse_socket)
+    pub fn new(host: &'a str, create_socket: bool) -> Result<Self> {
+        let socket = create_socket
             .then(|| {
                 TempSocket::new(|builder| {
                     builder.prefix("aspect-reauth-");


### PR DESCRIPTION
The semantics of `--reuse-socket` were confusing; `--create-socket` tries to be more straightforward, a true value indicates that the program is going to do something (which seems more intuitive.)

This also should open the door for inferring the value as in #9 if the flag is not specified (probably by making it an enum type rather than an `Option<bool>` and making the default value something like `infer`.)