### PR TITLE
Check before refreshing local credentials

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -151,12 +151,7 @@ fn needs_refresh(mut credential_cmd: Command, args: &Args) -> Result<bool> {
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()
-        .with_context(|| {
-            format!(
-                "failed to run {} on {}",
-                &args.credential_helper, &args.host
-            )
-        })?;
+        .with_context(|| format!("failed to spawn: {:?}", credential_cmd))?;
     let mut stdin = child.stdin.take().context("failed to open stdin")?;
     let test_string = format!(concat!(r#"{{"uri":"https://{}"}}"#, "\n"), &args.remote);
     thread::spawn(move || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,10 +88,11 @@ fn main() -> Result<()> {
         Ok(())
     });
 
-    let (ssh, remote_refresh) = ssh_needs_refresh(&args)?;
+    let ssh_remote_result = ssh_needs_refresh(&args);
     local_handle
         .join()
         .map_err(|e| anyhow::anyhow!("thread panic: {:?}", e))??;
+    let (ssh, remote_refresh) = ssh_remote_result?;
     if !remote_refresh {
         println!("Credential refresh not needed. Have a nice day.");
         return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,9 @@ fn main() -> Result<()> {
         eprintln!("The -p / --persist flag is deprecated and now a no-op, please do not use it.");
     }
 
-    if args.force || needs_refresh(Command::new(&args.credential_helper), &args)? {
+    if !args.force && !needs_refresh(Command::new(&args.credential_helper), &args)? {
+        println!("Local credentials are valid");
+    } else {
         let status = Command::new(&args.credential_helper)
             .arg("login")
             .arg(&args.remote)

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,10 +88,16 @@ fn main() -> Result<()> {
         Ok(())
     });
 
-    let ssh_remote_result = ssh_needs_refresh(&args);
+    let ssh_remote_result = ssh_needs_refresh(&args).with_context(|| {
+        format!(
+            "failed to run {} on {}",
+            &args.credential_helper, &args.host
+        )
+    });
     local_handle
         .join()
-        .map_err(|e| anyhow::anyhow!("thread panic: {:?}", e))??;
+        .map_err(|e| anyhow::anyhow!("thread panic: {:?}", e))?
+        .with_context(|| format!("failed to run {}", &args.credential_helper))?;
     let (ssh, remote_refresh) = ssh_remote_result?;
     if !remote_refresh {
         println!("Credential refresh not needed. Have a nice day.");


### PR DESCRIPTION
This was an experiment in checking the local credential as well as the remote credential, and only refreshing the local credential when it was expired (rather than unconditionally refreshing it whenever the remote credential was expired.)

This doesn’t actually save on anything that at least I find particularly irritating — the browser window opening is actually a little less disruptive when it’s more predictable, and the number of password prompts does not seem to be reduced (since empirically I have to enter my password every time I access the key whether it got refreshed or not.) It also introduces a bit more complexity around threads and error reporting.

But if we wanted to do it, this is a way we could do it.