### PR TITLE
Infer or set whether to create our own socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,7 @@ checksum = "2f8fe839464d4e4b37d756d7e910063696af79a7e877282cb1825e4ec5f10833"
 dependencies = [
  "byteorder",
  "dbus-secret-service",
+ "linux-keyutils",
  "log",
  "security-framework 2.11.1",
  "security-framework 3.2.0",
@@ -313,6 +314,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
 dependencies = [
  "pkg-config",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -426,15 +437,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
@@ -738,19 +749,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "aspect-reauth"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aspect-reauth"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Stairwell, Inc."]
 edition = "2021"
 description = "Sync fresh Aspect credentials with your dev VM"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0.95"
 clap = { version = "4.5.29", features = ["env", "derive"] }
-keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "sync-secret-service"] }
+keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "linux-native-sync-persistent"] }
 regex = "1.11.1"
 tempfile = "3.16.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,15 +34,15 @@ const DEFAULT_HELPER: &str = "aspect-credential-helper";
 #[command(version, about)]
 struct Args {
     /// SSH hostname to which to sync credential
-    #[arg(default_value_t = String::from("devbox"))]
+    #[arg(default_value = "devbox")]
     host: String,
 
     /// Aspect remote DNS name
-    #[arg(env = "ASPECT_REMOTE", default_value_t = DEFAULT_REMOTE.into(), long)]
+    #[arg(env = "ASPECT_REMOTE", default_value = DEFAULT_REMOTE, long)]
     remote: String,
 
     /// Aspect credential helper executable name
-    #[arg(env = "ASPECT_CREDENTIAL_HELPER", default_value_t = DEFAULT_HELPER.into(), long)]
+    #[arg(env = "ASPECT_CREDENTIAL_HELPER", default_value = DEFAULT_HELPER, long)]
     credential_helper: String,
 
     /// Force re-login even if the credentials are still valid

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod ssh_mux;
 use std::{
     io::Write,
     process::{Command, Stdio},
+    str::FromStr,
     thread,
 };
 
@@ -53,11 +54,16 @@ struct Args {
     #[arg(short, long)]
     session_keyring: bool,
 
-    /// Create a temporary socket
-    #[arg(short, long)]
-    create_socket: Option<bool>,
+    /// Create a temporary ssh control socket [true false infer]
+    #[arg(short, long, conflicts_with = "no_create_socket", default_value = "infer",
+          default_missing_value = "true", num_args = 0..=1, require_equals = true)]
+    create_socket: CreateSocket,
 
-    /// Reuse existing socket (Deprecated: use --create-socket=false instead)
+    /// Do not create a temporary ssh control socket
+    #[arg(short = 'C', long, conflicts_with = "create_socket")]
+    no_create_socket: bool,
+
+    /// Reuse existing socket (Deprecated: use --no-create-socket instead)
     #[arg(short, long)]
     _reuse_socket: bool,
 
@@ -66,19 +72,28 @@ struct Args {
     _persist: bool,
 }
 
+#[derive(Clone, Copy)]
+enum CreateSocket {
+    Infer,
+    Value(bool),
+}
+
 fn main() -> Result<()> {
     let mut args = Args::parse();
+    if args.no_create_socket {
+        args.create_socket = CreateSocket::Value(false);
+    }
     if args._persist {
         eprintln!("The -p / --persist flag is deprecated, please do not use it.");
     }
     if args._reuse_socket {
         eprintln!("The -r / --reuse-socket flag is deprecated, please do not use it.");
-        args.create_socket = Some(false);
+        args.create_socket = CreateSocket::Value(false);
     }
     let args = args;
 
-    let ssh =
-        SshMux::new(&args.host, args.create_socket).context("failed setting up ssh session")?;
+    let ssh = SshMux::new(&args.host, args.create_socket.into())
+        .context("failed setting up ssh session")?;
 
     if !args.force {
         // Check the error output from the credential helper. If it says we need to rerun
@@ -169,4 +184,26 @@ fn main() -> Result<()> {
         args.host
     );
     Ok(())
+}
+
+impl FromStr for CreateSocket {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        if s == "infer" {
+            return Ok(CreateSocket::Infer);
+        }
+        if let Ok(b) = s.parse() {
+            return Ok(CreateSocket::Value(b));
+        }
+        anyhow::bail!("provided string was not `true`, `false`, or `infer`");
+    }
+}
+
+impl From<CreateSocket> for Option<bool> {
+    fn from(v: CreateSocket) -> Self {
+        match v {
+            CreateSocket::Infer => None,
+            CreateSocket::Value(b) => Some(b),
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,9 +53,14 @@ struct Args {
     #[arg(short, long)]
     session_keyring: bool,
 
-    /// Create a temporary socket
-    #[arg(short, long)]
+    /// Create a temporary SSH control socket (if unset, this is automatically inferred)
+    #[arg(short, long, conflicts_with = "no_create_socket", default_missing_value = "true",
+          num_args = 0..=1, require_equals = true)]
     create_socket: Option<bool>,
+
+    /// Do not create a temporary SSH control socket
+    #[arg(short = 'C', long, conflicts_with = "create_socket")]
+    no_create_socket: bool,
 
     /// Reuse existing socket (Deprecated: use --create-socket=false instead)
     #[arg(short, long)]
@@ -68,6 +73,9 @@ struct Args {
 
 fn main() -> Result<()> {
     let mut args = Args::parse();
+    if args.no_create_socket {
+        args.create_socket = Some(false);
+    }
     if args._persist {
         eprintln!("The -p / --persist flag is deprecated, please do not use it.");
     }

--- a/src/ssh_mux/config.rs
+++ b/src/ssh_mux/config.rs
@@ -13,39 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::Result;
 use std::process::Command;
 
-pub fn has_user_socket(host: &str) -> Result<bool> {
+pub fn infer_create_socket(host: &str) -> bool {
     // Get the output of `ssh -G <host>` this will have a standard
     // lowercase represesntation of:
     //
     // <key> <value>
     //
     // so a basic match should be enough.
-    let output = Command::new("ssh").arg("-G").arg(host).output()?;
-
+    let Ok(output) = Command::new("ssh").args(["-G", "--", host]).output() else {
+        return false;
+    };
     if !output.status.success() {
-        anyhow::bail!(
-            "failed to check for existing control socket: {}\n\n{}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr).trim(),
-        );
+        return false;
     }
-    let stdout = String::from_utf8(output.stdout)?;
-
-    let mut has_controlmaster_auto = false;
-    let mut has_controlpersist = false;
-
-    for line in stdout.lines() {
-        let line = line.trim();
-        if line == "controlmaster auto" {
-            has_controlmaster_auto = true;
-        }
-        if line.starts_with("controlpersist") {
-            has_controlpersist = true;
-        }
-    }
-
-    Ok(has_controlmaster_auto && has_controlpersist)
+    String::from_utf8(output.stdout)
+        .map(|stdout| !stdout.lines().any(|line| line == "controlmaster auto"))
+        .unwrap_or(false)
 }

--- a/src/ssh_mux/mod.rs
+++ b/src/ssh_mux/mod.rs
@@ -19,6 +19,7 @@ mod temp_socket;
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result};
+use config::infer_create_socket;
 use temp_socket::TempSocket;
 
 /// A batched SSH command multiplexer.
@@ -35,11 +36,8 @@ pub struct SshMux<'a> {
 
 impl<'a> SshMux<'a> {
     pub fn new(host: &'a str, create_socket: Option<bool>) -> Result<Self> {
-        let create_socket = match create_socket {
-            Some(b) => b,
-            None => !config::has_user_socket(host)?,
-        };
         let socket = create_socket
+            .unwrap_or_else(|| infer_create_socket(host))
             .then(|| {
                 TempSocket::new(|builder| {
                     builder.prefix("aspect-reauth-");


### PR DESCRIPTION
This integrates #9 and #20 into one PR.

We add a `--create-socket` flag, deprecating `--reuse-socket` since the former seems more intuitive. If `--create-socket` is true, then the program will create and manage its own temporary SSH control socket; if it is false, the program will not. If it is unspecified, then the program will try to parse the output of `ssh -G` to decide whether or not to create a socket, specifically looking for a `controlmaster auto` line that would imply that the user is already using their own SSH connection multiplexing.

This PR also includes a couple other changes:

- We switch to using the `linux-native-sync-persistent` keyring on Linux, in the hopes that this will work with what `aspect-credential-helper` will be using.
- Increments the version to 0.4.0.