### PR TITLE
Override default settings with build.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ cargo build --release &&
   sudo install target/release/aspect-reauth /usr/local/bin
 ```
 
+You may want to customize the default remote name or possibly the default name of the Aspect credential helper binary. These can be customized by setting the `ASPECT_REMOTE` and `ASPECT_CREDENTIAL_HELPER` environment variables. If they are set at runtime, they override the defaults; if they are set at build time, they become the defaults for that binary.
+
+E.g.:
+
+```sh
+env ASPECT_REMOTE=aw-remote-ext.mydomain.example \
+    ASPECT_CREDENTIAL_HELPER=credential-helper \
+    cargo build --release
+```
+
 ## FAQ
 
 ### Why do it this way?

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+use std::env;
+
+fn main() {
+    let default_remote = env::var("ASPECT_REMOTE")
+        .unwrap_or_else(|_| "aw-remote-ext.buildremote.stairwell.io".into());
+    let default_helper = env::var("ASPECT_CREDENTIAL_HELPER")
+        .unwrap_or_else(|_| "aspect-credential-helper".into());
+
+    println!("cargo::rerun-if-env-changed=ASPECT_REMOTE");
+    println!("cargo::rerun-if-env-changed=ASPECT_CREDENTIAL_HELPER");
+    println!("cargo::rustc-env=ASPECT_REMOTE={}", default_remote);
+    println!("cargo::rustc-env=ASPECT_CREDENTIAL_HELPER={}", default_helper);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,8 @@ use keyring::Entry;
 use regex::bytes::Regex;
 use ssh_mux::SshMux;
 
-const DEFAULT_REMOTE: &str = "aw-remote-ext.buildremote.stairwell.io";
-const DEFAULT_HELPER: &str = "aspect-credential-helper";
+const DEFAULT_REMOTE: &str = env!("ASPECT_REMOTE");
+const DEFAULT_HELPER: &str = env!("ASPECT_CREDENTIAL_HELPER");
 
 #[derive(Parser)]
 #[command(version, about)]


### PR DESCRIPTION
This lets different organizations more easily use this tool by making the default remote name and credential helper binary name configurable at build time.