### PR TITLE
GitHub workflow does locked build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
     - uses: stairwell-inc/checkout@v4
     - run: rustup target add ${{ matrix.target }} && rustup update
-    - run: cargo build --release --target ${{ matrix.target }}
+    - run: cargo build --locked --release --target ${{ matrix.target }}
     - uses: stairwell-inc/upload-artifact@v4
       with:
         name: aspect-reauth-${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aspect-reauth"
-version = "0.5.0"
+version = "0.4.0"
 authors = ["Stairwell, Inc."]
 edition = "2021"
 description = "Sync fresh Aspect credentials with your dev VM"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aspect-reauth"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Stairwell, Inc."]
 edition = "2021"
 description = "Sync fresh Aspect credentials with your dev VM"


### PR DESCRIPTION
This should cause checks to fail if Cargo.lock and Cargo.toml ever get out of sync again.