### PR TITLE
Remove deprecated flags, do some cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "aspect-reauth"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aspect-reauth"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Stairwell, Inc."]
 edition = "2021"
 description = "Sync fresh Aspect credentials with your dev VM"

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,26 +61,11 @@ struct Args {
     /// Do not create a temporary SSH control socket
     #[arg(short = 'C', long, conflicts_with = "create_socket")]
     no_create_socket: bool,
-
-    /// Reuse existing socket (Deprecated: use --create-socket=false instead)
-    #[arg(short, long)]
-    _reuse_socket: bool,
-
-    /// Use persistent keyring (Deprecated: now default)
-    #[arg(short, long)]
-    _persist: bool,
 }
 
 fn main() -> Result<()> {
     let mut args = Args::parse();
     if args.no_create_socket {
-        args.create_socket = Some(false);
-    }
-    if args._persist {
-        eprintln!("The -p / --persist flag is deprecated, please do not use it.");
-    }
-    if args._reuse_socket {
-        eprintln!("The -r / --reuse-socket flag is deprecated, please do not use it.");
         args.create_socket = Some(false);
     }
     let args = args;

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,48 +73,11 @@ fn main() -> Result<()> {
     let ssh =
         SshMux::new(&args.host, args.create_socket).context("failed setting up ssh session")?;
 
-    if !args.force {
-        // Check the error output from the credential helper. If it says we need to rerun
-        // "credential-helper login", we do it.
-        let mut child = ssh
-            .command(&args.credential_helper)
-            .arg("get")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-            .with_context(|| {
-                format!(
-                    "failed to run {} on {}",
-                    &args.credential_helper, &args.host
-                )
-            })?;
-        let mut stdin = child.stdin.take().context("failed to open stdin")?;
-        let test_string = format!(concat!(r#"{{"uri":"https://{}"}}"#, "\n"), &args.remote);
-        thread::spawn(move || {
-            let _ = stdin.write_all(test_string.as_bytes());
-        });
-        let output = child
-            .wait_with_output()
-            .with_context(|| format!("failed waiting for {}", &args.credential_helper))?;
-        if !output.status.success() {
-            let re = Regex::new(&format!(
-                r"(?mis)please\s+run.*{}\s+login",
-                regex::escape(&args.credential_helper)
-            ))
-            .context("failed to compile regex")?;
-            if !re.is_match(&output.stderr) {
-                anyhow::bail!(
-                    "{} get: {}\n\n{}",
-                    args.credential_helper,
-                    output.status,
-                    String::from_utf8_lossy(&output.stderr).trim(),
-                );
-            }
-        } else {
-            println!("Credential refresh not needed. Have a nice day.");
-            return Ok(());
-        }
+    if !args.force && !needs_refresh(&args, &ssh)? {
+        // If we have valid credentials and didn't ask to unconditionally refresh them, then we're
+        // done.
+        println!("Credential refresh not needed. Have a nice day.");
+        return Ok(());
     }
 
     let status = Command::new(&args.credential_helper)
@@ -162,4 +125,45 @@ fn main() -> Result<()> {
         args.host
     );
     Ok(())
+}
+
+fn needs_refresh(args: &Args, ssh: &SshMux) -> Result<bool> {
+    let mut child = ssh
+        .command(&args.credential_helper)
+        .arg("get")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| {
+            format!(
+                "failed to run {} on {}",
+                &args.credential_helper, &args.host
+            )
+        })?;
+    let mut stdin = child.stdin.take().context("failed to open stdin")?;
+    let test_string = format!(concat!(r#"{{"uri":"https://{}"}}"#, "\n"), &args.remote);
+    thread::spawn(move || {
+        let _ = stdin.write_all(test_string.as_bytes());
+    });
+    let output = child
+        .wait_with_output()
+        .with_context(|| format!("failed waiting for {}", &args.credential_helper))?;
+    if !output.status.success() {
+        let re = Regex::new(&format!(
+            r"(?mis)please\s+run.*{}\s+login",
+            regex::escape(&args.credential_helper)
+        ))
+        .context("failed to compile regex")?;
+        if !re.is_match(&output.stderr) {
+            anyhow::bail!(
+                "{} get: {}\n\n{}",
+                args.credential_helper,
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim(),
+            );
+        }
+        return Ok(true);
+    }
+    Ok(false)
 }

--- a/src/ssh_mux/mod.rs
+++ b/src/ssh_mux/mod.rs
@@ -38,11 +38,7 @@ impl<'a> SshMux<'a> {
     pub fn new(host: &'a str, create_socket: Option<bool>) -> Result<Self> {
         let socket = create_socket
             .unwrap_or_else(|| infer_create_socket(host))
-            .then(|| {
-                TempSocket::new(|builder| {
-                    builder.prefix("aspect-reauth-");
-                })
-            })
+            .then(|| TempSocket::new("aspect-reauth-"))
             .transpose()?;
         let mut cmd = Command::new("ssh");
         if let Some(socket) = &socket {

--- a/src/ssh_mux/temp_socket.rs
+++ b/src/ssh_mux/temp_socket.rs
@@ -16,7 +16,6 @@
 use std::{ffi::OsStr, fs::remove_dir_all, path::Path};
 
 use anyhow::Result;
-use tempfile::TempDir;
 
 /// Exposes and controls a path suitable for use as a temporary socket. The path is made available
 /// by `AsRef<OsStr>` on `&TempSocket`, so that a reference to this may be passed directly to

--- a/src/ssh_mux/temp_socket.rs
+++ b/src/ssh_mux/temp_socket.rs
@@ -31,15 +31,14 @@ pub struct TempSocket {
 }
 
 impl TempSocket {
-    pub fn new(opts: impl FnOnce(&mut tempfile::Builder)) -> Result<Self> {
+    pub fn new(prefix: &str) -> Result<Self> {
         let mut builder = tempfile::Builder::new();
         #[cfg(unix)]
         {
             use std::{fs::Permissions, os::unix::fs::PermissionsExt};
             builder.permissions(Permissions::from_mode(0o700));
         }
-        opts(&mut builder);
-        Ok(builder.tempdir()?.into())
+        Ok(builder.prefix(prefix).tempdir()?.into())
     }
 }
 

--- a/src/ssh_mux/temp_socket.rs
+++ b/src/ssh_mux/temp_socket.rs
@@ -38,17 +38,13 @@ impl TempSocket {
             use std::{fs::Permissions, os::unix::fs::PermissionsExt};
             builder.permissions(Permissions::from_mode(0o700));
         }
-        Ok(builder.prefix(prefix).tempdir()?.into())
-    }
-}
-
-impl From<TempDir> for TempSocket {
-    fn from(dir: TempDir) -> Self {
+        let dir = builder.prefix(prefix).tempdir()?;
         let mut path = dir.into_path();
+        // --- no early-return allowed from here ---
         path.push("sock");
-        TempSocket {
+        Ok(TempSocket {
             path: path.into_boxed_path(),
-        }
+        })
     }
 }
 


### PR DESCRIPTION
Removes the previously-deprecated flags now that Stairwell doesn’t use them. Goes ahead and calls this version 0.5.0.

As well, takes care of a few pieces of the lower-hanging fruit from the code review today; in brief:

* separate things should be separate: `TempSocket` should completely own its initialization rather than ping-ponging the builder with `SshMux`.
* There was a too-long if statement in main that was making it hard to follow the logic.
* `From` implementations are for consuming conversions: remove the `From<TempDir>` and inline it into `TempSocket::new` (with a note in a comment to remind us not to use the `?` operator after we've called `dir.into_path()`.)