### PR TITLE
Bump to v0.7.0, prep Cargo.toml for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "aspect-reauth"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "aspect-reauth"
-homepage = "https://github.com/stairwell-inc/aspect-reauth"
 version = "0.7.0"
 authors = ["Stairwell, Inc."]
 edition = "2021"
-description = "Sync fresh Aspect credentials with your dev VM"
+homepage = "https://github.com/stairwell-inc/aspect-reauth"
 license = "Apache-2.0"
+description = "Sync fresh Aspect credentials with your dev VM"
 
 exclude = [
     ".github/**",
@@ -14,7 +14,10 @@ exclude = [
 
 [dependencies]
 anyhow = "1.0.95"
-clap = { version = "4.5.29", features = ["env", "derive"] }
-keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "linux-native-sync-persistent"] }
+clap = { version = "4.5.29", features = ["derive", "env"] }
 regex = "1.11.1"
 tempfile = "3.16.0"
+
+[dependencies.keyring]
+version = "3.6.1"
+features = ["apple-native", "linux-native-sync-persistent", "windows-native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aspect-reauth"
 version = "0.7.0"
-authors = ["Stairwell, Inc."]
+authors = ["Stairwell, Inc. <eng@stairwell.com>"]
 edition = "2021"
 homepage = "https://github.com/stairwell-inc/aspect-reauth"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "aspect-reauth"
-version = "0.6.0"
+homepage = "https://github.com/stairwell-inc/aspect-reauth"
+version = "0.7.0"
 authors = ["Stairwell, Inc."]
 edition = "2021"
 description = "Sync fresh Aspect credentials with your dev VM"
 license = "Apache-2.0"
+
+exclude = [
+    ".github/**",
+    ".gitignore",
+]
 
 [dependencies]
 anyhow = "1.0.95"


### PR DESCRIPTION
Excludes Git-specific stuff from the crate upload.

Adds the GitHub repository as a homepage so there is some kind of landing page for documentation.

Tries to apply the [`Cargo.toml` conventions][0].

[0]: https://doc.rust-lang.org/style-guide/cargo.html