### PR TITLE
macos codesigning workflow fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,9 +29,8 @@ jobs:
     - run: sudo sh -c 'apt update && apt install libdbus-1-dev'
       if: matrix.os == 'ubuntu-latest'
     - run: |
-        set -e
-        rustup toolchain install stable --profile minimal
-        rustup target add ${{ matrix.target }}
+        rustup toolchain install stable --profile minimal || exit 1
+        rustup target add ${{ matrix.target }} || exit 1
     - uses: stairwell-inc/checkout@v4
     - uses: stairwell-inc/cache@5a3ec84eff668545956fd18022155c47e93e2684
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,13 +29,13 @@ jobs:
     - run: sudo sh -c 'apt update && apt install libdbus-1-dev'
       if: matrix.os == 'ubuntu-latest'
     - uses: stairwell-inc/checkout@v4
-    - uses: stairwell-inc/cache@v4
+    - uses: stairwell-inc/cache@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: ~/.cargo
         key: cargo-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
         restore-keys: |
           cargo-${{ matrix.target }}-
-    - uses: stairwell-inc/cache@v4
+    - uses: stairwell-inc/cache@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: target
         key: target-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-${{ github.ref }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,13 +32,13 @@ jobs:
         rustup toolchain install stable --profile minimal || exit 1
         rustup target add ${{ matrix.target }} || exit 1
     - uses: stairwell-inc/checkout@v4
-    - uses: stairwell-inc/cache@5a3ec84eff668545956fd18022155c47e93e2684
+    - uses: stairwell-inc/cache@v4
       with:
         path: ~/.cargo
         key: cargo-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
         restore-keys: |
           cargo-${{ matrix.target }}-
-    - uses: stairwell-inc/cache@5a3ec84eff668545956fd18022155c47e93e2684
+    - uses: stairwell-inc/cache@v4
       with:
         path: target
         key: target-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-${{ github.ref }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,10 @@ jobs:
     steps:
     - run: sudo sh -c 'apt update && apt install libdbus-1-dev'
       if: matrix.os == 'ubuntu-latest'
+    - run: |
+        set -e
+        rustup toolchain install stable --profile minimal
+        rustup target add ${{ matrix.target }}
     - uses: stairwell-inc/checkout@v4
     - uses: stairwell-inc/cache@5a3ec84eff668545956fd18022155c47e93e2684
       with:
@@ -42,7 +46,6 @@ jobs:
         restore-keys: |
           target-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-
           target-${{ matrix.target }}-
-    - run: rustup target add ${{ matrix.target }} && rustup update
     - run: cargo build --locked --release --target ${{ matrix.target }}
     - uses: stairwell-inc/upload-artifact@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,10 +49,3 @@ jobs:
         name: aspect-reauth-${{ matrix.target }}
         path: target/${{ matrix.target}}/release/aspect-reauth${{ matrix.suffix }}
         retention-days: ${{ github.event_name == 'pull_request' && 7 || '' }}
-  format:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-    - uses: stairwell-inc/checkout@v4
-    - run: rustup update
-    - run: cargo fmt -- --check

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,19 @@ jobs:
     - run: sudo sh -c 'apt update && apt install libdbus-1-dev'
       if: matrix.os == 'ubuntu-latest'
     - uses: stairwell-inc/checkout@v4
+    - uses: stairwell-inc/cache@v4
+      with:
+        path: ~/.cargo
+        key: cargo-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          cargo-${{ matrix.target }}-
+    - uses: stairwell-inc/cache@v4
+      with:
+        path: target
+        key: target-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-${{ github.ref }}
+        restore-keys: |
+          target-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-
+          target-${{ matrix.target }}-
     - run: rustup target add ${{ matrix.target }} && rustup update
     - run: cargo build --locked --release --target ${{ matrix.target }}
     - uses: stairwell-inc/upload-artifact@v4

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,15 @@
+name: Format
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: stairwell-inc/checkout@v4
+    - run: rustup update
+    - run: cargo fmt -- --check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,19 +35,11 @@ jobs:
       run: |
         set -e
         xcrun notarytool store-credentials --apple-id "$DEV_ACCOUNT" --team-id 677UQVFGY8 --password "$NOTARY_PASS" notary-aspect-reauth
-        xcrun notarytool submit aspect-reauth-signed --keychain-profile notary-aspect-reauth --wait
-        cp aspect-reauth-signed .tmp.$$
-        trap "rm -f .tmp.$$" EXIT
-        xcrun stapler staple .tmp.$$
-        mv .tmp.$$ aspect-reauth-release
-        spctl --assess -vv --type execute aspect-reauth
+        zip -qr aspect-reauth-notary-bundle.zip aspect-reauth-signed
+        xcrun notarytool submit aspect-reauth-notary-bundle.zip --keychain-profile notary-aspect-reauth --wait
 
     - uses: stairwell-inc/upload-artifact@v4
       with:
-        name: aspect-reauth-darwin-steps
-        path: aspect-reauth-*
-    - uses: stairwell-inc/upload-artifact@v4
-      with:
         name: aspect-reauth-darwin
-        path: aspect-reauth-release
+        path: aspect-reauth-signed
         if-no-files-found: error

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,8 @@ jobs:
     environment: macos
     steps:
     - uses: stairwell-inc/download-artifact@v4
-      pattern: aspect-reauth-*-apple-darwin
+      with:
+        pattern: aspect-reauth-*-apple-darwin
     - run: |
         lipo -create -output aspect-reauth-universal aspect-reauth-{x86_64,aarch64}-apple-darwin/aspect-reauth
     - run: rm -rf aspect-reauth-*-apple-darwin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,5 @@
 name: Release
 
-env:
-  NOTARY_PASS: ${{ secrets.NOTARY_PASS }}
-  DEV_ACCOUNT: ${{ secrets.DEV_ACCOUNT }}
-
 on:
   push:
     tags: ["v*"]
@@ -24,13 +20,18 @@ jobs:
     - run: |
         lipo -create -output aspect-reauth-universal aspect-reauth-{x86_64,aarch64}-apple-darwin/aspect-reauth
     - run: rm -rf aspect-reauth-*-apple-darwin
+
     - run: |
         set -e
         cp aspect-reauth-universal .tmp.$$
         trap "rm -f .tmp.$$" EXIT
         codesign -s 'Developer ID Application: Stairwell, Inc. (677UQVFGY8)' -f --timestamp -o runtime .tmp.$$
         mv .tmp.$$ aspect-reauth-signed
-    - run: |
+
+    - env:
+        NOTARY_PASS: ${{ secrets.NOTARY_PASS }}
+        DEV_ACCOUNT: ${{ secrets.DEV_ACCOUNT }}
+      run: |
         set -e
         xcrun notarytool store-credentials --apple-id "$DEV_ACCOUNT" --team-id 677UQVFGY8 --password "$NOTARY_PASS" notary-aspect-reauth
         xcrun notarytool submit aspect-reauth-signed --keychain-profile notary-aspect-reauth --wait
@@ -39,6 +40,7 @@ jobs:
         xcrun stapler staple .tmp.$$
         mv .tmp.$$ aspect-reauth-release
         spctl --assess -vv --type execute aspect-reauth
+
     - uses: stairwell-inc/upload-artifact@v4
       with:
         name: aspect-reauth-darwin-steps

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,11 @@ jobs:
 
     - name: Get version
       id: get-version
-      run: echo "version=$(./aspect-reauth --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+      run: |
+        set -e
+        { echo -n version=
+          ./aspect-reauth --version | cut -d' ' -f2
+        } >> $GITHUB_OUTPUT
 
     - uses: stairwell-inc/upload-artifact@v4
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,9 @@
 name: Release
 
+env:
+  DEVELOPER_ID: "Developer ID Application: Stairwell, Inc. (677UQVFGY8)"
+  INSTALLER_ID: "Developer ID Installer: Stairwell, Inc. (677UQVFGY8)"
+
 on:
   push:
     tags: ["v*"]
@@ -32,8 +36,13 @@ jobs:
         set -e
         cp aspect-reauth-universal .tmp.$$
         trap "rm -f .tmp.$$" EXIT
-        codesign -s 'Developer ID Application: Stairwell, Inc. (677UQVFGY8)' -f --timestamp -o runtime .tmp.$$
+        codesign -s "${{ env.DEVELOPER_ID }}" -f --timestamp -o runtime .tmp.$$
+        chmod +x .tmp.$$
         mv .tmp.$$ aspect-reauth
+
+    - name: Get version
+      id: get-version
+      run: echo "version=$(./aspect-reauth --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
 
     - uses: stairwell-inc/upload-artifact@v4
       with:
@@ -46,10 +55,20 @@ jobs:
       run: |
         set -e
         xcrun notarytool store-credentials --apple-id "$DEV_ACCOUNT" --team-id 677UQVFGY8 --password "$NOTARY_PASS" notary-aspect-reauth
-        zip -qr aspect-reauth-notary-bundle.zip aspect-reauth
-        xcrun notarytool submit aspect-reauth-notary-bundle.zip --keychain-profile notary-aspect-reauth --wait
+        mkdir .root.$$
+        trap "rm -rf .root.$$" EXIT
+        cp aspect-reauth .root.$$
+        pkgbuild --root .root.$$ \
+                 --identifier com.stairwell.aspect-reauth \
+                 --version "${{ steps.get-version.outputs.version }}" \
+                 --install-location /usr/local/bin \
+                 --sign "${{ env.INSTALLER_ID }}" \
+                 aspect-reauth.pkg
+        xcrun notarytool submit aspect-reauth.pkg --keychain-profile notary-aspect-reauth --wait
+        xcrun stapler staple aspect-reauth.pkg
+        spctl --assess -vv --type install aspect-reauth.pkg
 
     - uses: stairwell-inc/upload-artifact@v4
       with:
-        name: aspect-reauth-notary-bundle
-        path: aspect-reauth-notary-bundle.zip
+        name: aspect-reauth-pkg-darwin
+        path: aspect-reauth.pkg

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,5 @@
 name: Release
 
-env:
-  DEVELOPER_ID: "Developer ID Application: Stairwell, Inc. (677UQVFGY8)"
-  INSTALLER_ID: "Developer ID Installer: Stairwell, Inc. (677UQVFGY8)"
-
 on:
   push:
     tags: ["v*"]
@@ -35,7 +31,7 @@ jobs:
     - run: |
         cp aspect-reauth-universal .tmp.$$
         trap "rm -f .tmp.$$" EXIT
-        codesign -s "${{ env.DEVELOPER_ID }}" -f --timestamp -o runtime .tmp.$$
+        codesign -s "Developer ID Application: Stairwell, Inc. (677UQVFGY8)" -f --timestamp -o runtime .tmp.$$
         chmod +x .tmp.$$
         mv .tmp.$$ aspect-reauth
 
@@ -63,7 +59,7 @@ jobs:
                  --identifier com.stairwell.aspect-reauth \
                  --version "${{ steps.get-version.outputs.version }}" \
                  --install-location /usr/local/bin \
-                 --sign "${{ env.INSTALLER_ID }}" \
+                 --sign "Developer ID Installer: Stairwell, Inc. (677UQVFGY8)" \
                  aspect-reauth.pkg
         xcrun notarytool submit aspect-reauth.pkg --keychain-profile notary-aspect-reauth --wait
         xcrun stapler staple aspect-reauth.pkg

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: [self-hosted, macOS]
     environment: macos
     steps:
+    - uses: stairwell-inc/checkout@v4
     - uses: stairwell-inc/download-artifact@v4
       with:
         pattern: aspect-reauth-*-apple-darwin
@@ -22,12 +23,22 @@ jobs:
         lipo -create -output aspect-reauth-universal aspect-reauth-{x86_64,aarch64}-apple-darwin/aspect-reauth
     - run: rm -rf aspect-reauth-*-apple-darwin
 
+    - uses: stairwell-inc/upload-artifact@v4
+      with:
+        name: aspect-reauth-universal-darwin
+        path: aspect-reauth-universal
+
     - run: |
         set -e
         cp aspect-reauth-universal .tmp.$$
         trap "rm -f .tmp.$$" EXIT
         codesign -s 'Developer ID Application: Stairwell, Inc. (677UQVFGY8)' -f --timestamp -o runtime .tmp.$$
-        mv .tmp.$$ aspect-reauth-signed
+        mv .tmp.$$ aspect-reauth
+
+    - uses: stairwell-inc/upload-artifact@v4
+      with:
+        name: aspect-reauth-signed-darwin
+        path: aspect-reauth
 
     - env:
         NOTARY_PASS: ${{ secrets.NOTARY_PASS }}
@@ -35,11 +46,10 @@ jobs:
       run: |
         set -e
         xcrun notarytool store-credentials --apple-id "$DEV_ACCOUNT" --team-id 677UQVFGY8 --password "$NOTARY_PASS" notary-aspect-reauth
-        zip -qr aspect-reauth-notary-bundle.zip aspect-reauth-signed
+        zip -qr aspect-reauth-notary-bundle.zip aspect-reauth
         xcrun notarytool submit aspect-reauth-notary-bundle.zip --keychain-profile notary-aspect-reauth --wait
 
     - uses: stairwell-inc/upload-artifact@v4
       with:
-        name: aspect-reauth-darwin
-        path: aspect-reauth-signed
-        if-no-files-found: error
+        name: aspect-reauth-notary-bundle
+        path: aspect-reauth-notary-bundle.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
         trap "rm -rf .root.$$" EXIT
         cp aspect-reauth .root.$$
         pkgbuild --root .root.$$ \
-                 --identifier com.stairwell.aspect-reauth \
+                 --identifier com.stairwell.pkg.aspect-reauth \
                  --version "${{ steps.get-version.outputs.version }}" \
                  --install-location /usr/local/bin \
                  --sign "Developer ID Installer: Stairwell, Inc. (677UQVFGY8)" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,6 @@ jobs:
         path: aspect-reauth-universal
 
     - run: |
-        set -e
         cp aspect-reauth-universal .tmp.$$
         trap "rm -f .tmp.$$" EXIT
         codesign -s "${{ env.DEVELOPER_ID }}" -f --timestamp -o runtime .tmp.$$
@@ -43,7 +42,6 @@ jobs:
     - name: Get version
       id: get-version
       run: |
-        set -e
         { echo -n version=
           ./aspect-reauth --version | cut -d' ' -f2
         } >> $GITHUB_OUTPUT
@@ -57,7 +55,6 @@ jobs:
         NOTARY_PASS: ${{ secrets.NOTARY_PASS }}
         DEV_ACCOUNT: ${{ secrets.DEV_ACCOUNT }}
       run: |
-        set -e
         xcrun notarytool store-credentials --apple-id "$DEV_ACCOUNT" --team-id 677UQVFGY8 --password "$NOTARY_PASS" notary-aspect-reauth
         mkdir .root.$$
         trap "rm -rf .root.$$" EXIT


### PR DESCRIPTION
This results in a signed, notarized, stapled .pkg file containing a signed aspect-reauth binary that runs on my laptop. Apparently you can’t notarize anything other than a .zip, .pkg, .dmg, or .app, and you can’t just download a signed binary from the internet and run it — it has to come from a notarized source.

I spent some time trying to go down the road of notarizing the zip that GitHub creates in its upload-artifact action, but it was shockingly difficult to get at the actual zip itself rather than the zip’s contents from within a GitHub action, and besides, zip files cannot have their notarizations stapled, so you’d need either a network connection or to know how to run `xattr`.

This also turns on caching for the build workflow since that wound up  being the bottleneck on testing this.

And finally, I decided to move the Format job out of the Build workflow since formatting does not need to be run as a prerequisite to a release.