### PR TITLE
Autogenerate releases, publish crate

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,10 +43,12 @@ jobs:
           rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-
           rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-
     - run: |
-        rustup toolchain install ${{ env.RUSTC_VERSION }} --profile minimal || exit 1
-        rustup target add ${{ matrix.target }} || exit 1
+        rustup toolchain install ${{ env.RUSTC_VERSION }}
+        rustup target add ${{ matrix.target }}
+      shell: bash
     - id: set-profile
       run: echo profile=${{ github.event_name == 'pull_request' && 'fastbuild' || 'release' }} >> $GITHUB_OUTPUT
+      shell: bash
     - run: cargo build --locked --profile ${{ steps.set-profile.outputs.profile }} --target ${{ matrix.target }}
     - uses: stairwell-inc/upload-artifact@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,11 +37,11 @@ jobs:
         path: |
           ~/.cargo
           target
-        key: rust-${{ matrix.target }}-${{ env.RUSTC_VERSION }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          rust-${{ matrix.target }}-${{ env.RUSTC_VERSION }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-
-          rust-${{ matrix.target }}-${{ env.RUSTC_VERSION }}-${{ hashFiles('**/Cargo.lock') }}-
-          rust-${{ matrix.target }}-${{ env.RUSTC_VERSION }}-
+          rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-
+          rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-
+          rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-
     - run: |
         rustup toolchain install ${{ env.RUSTC_VERSION }} --profile minimal || exit 1
         rustup target add ${{ matrix.target }} || exit 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,17 +34,13 @@ jobs:
     - uses: stairwell-inc/checkout@v4
     - uses: stairwell-inc/cache@v4
       with:
-        path: ~/.cargo
-        key: cargo-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
+        path: |
+          ~/.cargo
+          target
+        key: rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
         restore-keys: |
-          cargo-${{ matrix.target }}-
-    - uses: stairwell-inc/cache@v4
-      with:
-        path: target
-        key: target-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-${{ github.ref }}
-        restore-keys: |
-          target-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-
-          target-${{ matrix.target }}-
+          rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-
+          rust-${{ matrix.target }}-
     - run: cargo build --locked --release --target ${{ matrix.target }}
     - uses: stairwell-inc/upload-artifact@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,8 +37,9 @@ jobs:
         path: |
           ~/.cargo
           target
-        key: rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
+        key: rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
+          rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-
           rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-
           rust-${{ matrix.target }}-
     - run: cargo build --locked --release --target ${{ matrix.target }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,3 +51,4 @@ jobs:
         name: aspect-reauth-${{ matrix.target }}
         path: target/${{ matrix.target}}/release/aspect-reauth${{ matrix.suffix }}
         retention-days: ${{ github.event_name == 'pull_request' && 7 || '' }}
+    - run: cargo publish --locked --dry-run --target ${{ matrix.target }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
           rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-
           rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-
           rust-${{ matrix.target }}-
-    - run: cargo build --locked ${{ github.event_name == 'pull_request' && '' || '--release' }} --target ${{ matrix.target }}
+    - run: cargo build --locked ${{ github.event_name != 'pull_request' && '--release' || '' }} --target ${{ matrix.target }}
     - uses: stairwell-inc/upload-artifact@v4
       with:
         name: aspect-reauth-${{ matrix.target }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: Build
 
+env:
+  RUSTC_VERSION: 1.86.0
+
 on:
   pull_request:
   push:
@@ -28,20 +31,20 @@ jobs:
     steps:
     - run: sudo sh -c 'apt update && apt install libdbus-1-dev'
       if: matrix.os == 'ubuntu-latest'
-    - run: |
-        rustup toolchain install stable --profile minimal || exit 1
-        rustup target add ${{ matrix.target }} || exit 1
     - uses: stairwell-inc/checkout@v4
     - uses: stairwell-inc/cache@v4
       with:
         path: |
           ~/.cargo
           target
-        key: rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: rust-${{ matrix.target }}-${{ env.RUSTC_VERSION }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-
-          rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-
-          rust-${{ matrix.target }}-
+          rust-${{ matrix.target }}-${{ env.RUSTC_VERSION }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-
+          rust-${{ matrix.target }}-${{ env.RUSTC_VERSION }}-${{ hashFiles('**/Cargo.lock') }}-
+          rust-${{ matrix.target }}-${{ env.RUSTC_VERSION }}-
+    - run: |
+        rustup toolchain install ${{ env.RUSTC_VERSION }} --profile minimal || exit 1
+        rustup target add ${{ matrix.target }} || exit 1
     - run: cargo build --locked ${{ github.event_name != 'pull_request' && '--release' || '' }} --target ${{ matrix.target }}
     - uses: stairwell-inc/upload-artifact@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
           rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-
           rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-
           rust-${{ matrix.target }}-
-    - run: cargo build --locked --release --target ${{ matrix.target }}
+    - run: cargo build --locked ${{ github.event_name == 'pull_request' && '' || '--release' }} --target ${{ matrix.target }}
     - uses: stairwell-inc/upload-artifact@v4
       with:
         name: aspect-reauth-${{ matrix.target }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,10 +45,12 @@ jobs:
     - run: |
         rustup toolchain install ${{ env.RUSTC_VERSION }} --profile minimal || exit 1
         rustup target add ${{ matrix.target }} || exit 1
-    - run: cargo build --locked ${{ github.event_name != 'pull_request' && '--release' || '' }} --target ${{ matrix.target }}
+    - id: set-profile
+      run: echo profile=${{ github.event_name == 'pull_request' && 'fastbuild' || 'release' }} >> $GITHUB_OUTPUT
+    - run: cargo build --locked --profile ${{ steps.set-profile.outputs.profile }} --target ${{ matrix.target }}
     - uses: stairwell-inc/upload-artifact@v4
       with:
         name: aspect-reauth-${{ matrix.target }}
-        path: target/${{ matrix.target}}/release/aspect-reauth${{ matrix.suffix }}
+        path: target/${{ matrix.target}}/${{ steps.set-profile.outputs.profile }}/aspect-reauth${{ matrix.suffix }}
         retention-days: ${{ github.event_name == 'pull_request' && 7 || '' }}
     - run: cargo publish --locked --dry-run --target ${{ matrix.target }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: stairwell-inc/checkout@v4
+    - run: |
+        { echo -n VERSION=
+          grep '^version =' Cargo.toml | head -n1 | sed 's/version = "\(.*\)"/\1/'
+        } >> $GITHUB_ENV
+    outputs:
+      version: ${{ env.VERSION }}
+
   build:
     uses: ./.github/workflows/build.yaml
 
@@ -22,7 +33,7 @@ jobs:
 
   macos-release:
     name: macOS Release
-    needs: build
+    needs: [build, get-version]
     runs-on: [self-hosted, macOS]
     environment: macos
     steps:
@@ -46,13 +57,6 @@ jobs:
         chmod +x .tmp.$$
         mv .tmp.$$ aspect-reauth
 
-    - name: Get version
-      id: get-version
-      run: |
-        { echo -n version=
-          ./aspect-reauth --version | cut -d' ' -f2
-        } >> $GITHUB_OUTPUT
-
     - uses: stairwell-inc/upload-artifact@v4
       with:
         name: aspect-reauth-signed-darwin
@@ -68,7 +72,7 @@ jobs:
         cp aspect-reauth .root.$$
         pkgbuild --root .root.$$ \
                  --identifier com.stairwell.pkg.aspect-reauth \
-                 --version "${{ steps.get-version.outputs.version }}" \
+                 --version "${{ needs.get-version.outputs.version }}" \
                  --install-location /usr/local/bin \
                  --sign "Developer ID Installer: Stairwell, Inc. (677UQVFGY8)" \
                  aspect-reauth.pkg
@@ -83,16 +87,18 @@ jobs:
         if-no-files-found: error
 
   github-release:
-    needs: [build, macos-release]
+    needs: [build, get-version, macos-release]
     runs-on: ubuntu-latest
     steps:
     - uses: stairwell-inc/download-artifact@v4
-    - run: |
+    - env:
+        VERSION: ${{ needs.get-version.outputs.version }}
+      run: |
         mkdir gh-release
-        ln aspect-reauth-pkg-darwin/aspect-reauth.pkg gh-release/aspect-reauth.pkg
-        ln aspect-reauth-signed-darwin/aspect-reauth gh-release/aspect-reauth-darwin
-        ln aspect-reauth-x86_64-unknown-linux-gnu/aspect-reauth gh-release/aspect-reauth-linux-amd64
-        ln aspect-reauth-x86_64-pc-windows-msvc/aspect-reauth.exe gh-release/aspect-reauth-windows-amd64.exe
+        ln aspect-reauth-pkg-darwin/aspect-reauth.pkg gh-release/aspect-reauth-$VERSION.pkg
+        ln aspect-reauth-signed-darwin/aspect-reauth gh-release/aspect-reauth-$VERSION-darwin
+        ln aspect-reauth-x86_64-unknown-linux-gnu/aspect-reauth gh-release/aspect-reauth-$VERSION-linux-amd64
+        ln aspect-reauth-x86_64-pc-windows-msvc/aspect-reauth.exe gh-release/aspect-reauth-$VERSION-windows-amd64.exe
     - uses: stairwell-inc/action-gh-release@v2
       with:
         draft: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,13 +86,13 @@ jobs:
     needs: [build, macos-release]
     runs-on: ubuntu-latest
     steps:
-    - run: stairwell-inc/download-artifact@v4
+    - uses: stairwell-inc/download-artifact@v4
     - run: |
         mkdir gh-release
         ln aspect-reauth-darwin/aspect-reauth-release gh-release/aspect-reauth-darwin
         ln aspect-reauth-x86_64-unknown-linux-gnu/aspect-reauth gh-release/aspect-reauth-linux-amd64
         ln aspect-reauth-x86_64-pc-windows-msvc gh-release/aspect-reauth-windows-amd64
-    - run: stairwell-inc/action-gh-release@v2
+    - uses: stairwell-inc/action-gh-release@v2
       with:
         draft: true
         files: gh-release/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
         ln aspect-reauth-pkg-darwin/aspect-reauth.pkg gh-release/aspect-reauth.pkg
         ln aspect-reauth-signed-darwin/aspect-reauth gh-release/aspect-reauth-darwin
         ln aspect-reauth-x86_64-unknown-linux-gnu/aspect-reauth gh-release/aspect-reauth-linux-amd64
-        ln aspect-reauth-x86_64-pc-windows-msvc gh-release/aspect-reauth-windows-amd64
+        ln aspect-reauth-x86_64-pc-windows-msvc/aspect-reauth.exe gh-release/aspect-reauth-windows-amd64.exe
     - uses: stairwell-inc/action-gh-release@v2
       with:
         draft: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Release
 
+env:
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
 on:
   push:
     tags: ["v*"]
@@ -8,6 +11,14 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+
+  publish:
+    name: Publish to Crates Registry
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: stairwell-inc/checkout@v4
+    - run: cargo publish --no-verify --locked
 
   macos-release:
     name: macOS Release
@@ -69,3 +80,20 @@ jobs:
       with:
         name: aspect-reauth-pkg-darwin
         path: aspect-reauth.pkg
+        if-no-files-found: error
+
+  github-release:
+    needs: [build, macos-release]
+    runs-on: ubuntu-latest
+    steps:
+    - run: stairwell-inc/download-artifact@v4
+    - run: |
+      mkdir gh-release
+      ln aspect-reauth-darwin/aspect-reauth-release gh-release/aspect-reauth-darwin
+      ln aspect-reauth-x86_64-unknown-linux-gnu/aspect-reauth gh-release/aspect-reauth-linux-amd64
+      ln aspect-reauth-x86_64-pc-windows-msvc gh-release/aspect-reauth-windows-amd64
+    - run: stairwell-inc/action-gh-release@v2
+      with:
+        draft: true
+        files: gh-release/*
+        generate_release_notes: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,10 +88,10 @@ jobs:
     steps:
     - run: stairwell-inc/download-artifact@v4
     - run: |
-      mkdir gh-release
-      ln aspect-reauth-darwin/aspect-reauth-release gh-release/aspect-reauth-darwin
-      ln aspect-reauth-x86_64-unknown-linux-gnu/aspect-reauth gh-release/aspect-reauth-linux-amd64
-      ln aspect-reauth-x86_64-pc-windows-msvc gh-release/aspect-reauth-windows-amd64
+        mkdir gh-release
+        ln aspect-reauth-darwin/aspect-reauth-release gh-release/aspect-reauth-darwin
+        ln aspect-reauth-x86_64-unknown-linux-gnu/aspect-reauth gh-release/aspect-reauth-linux-amd64
+        ln aspect-reauth-x86_64-pc-windows-msvc gh-release/aspect-reauth-windows-amd64
     - run: stairwell-inc/action-gh-release@v2
       with:
         draft: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,5 @@
 name: Release
 
-env:
-  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
 on:
   push:
     tags: ["v*"]
@@ -16,9 +13,12 @@ jobs:
     name: Publish to Crates Registry
     needs: build
     runs-on: ubuntu-latest
+    environment: crates-io
     steps:
     - uses: stairwell-inc/checkout@v4
     - run: cargo publish --no-verify --locked
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   macos-release:
     name: macOS Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,8 @@ jobs:
     - uses: stairwell-inc/download-artifact@v4
     - run: |
         mkdir gh-release
-        ln aspect-reauth-darwin/aspect-reauth-release gh-release/aspect-reauth-darwin
+        ln aspect-reauth-pkg-darwin/aspect-reauth.pkg gh-release/aspect-reauth.pkg
+        ln aspect-reauth-signed-darwin/aspect-reauth gh-release/aspect-reauth-darwin
         ln aspect-reauth-x86_64-unknown-linux-gnu/aspect-reauth gh-release/aspect-reauth-linux-amd64
         ln aspect-reauth-x86_64-pc-windows-msvc gh-release/aspect-reauth-windows-amd64
     - uses: stairwell-inc/action-gh-release@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ exclude = [
     ".gitignore",
 ]
 
+[profile.fastbuild]
+inherits = "dev"
+debug = "line-tables-only"
+
 [dependencies]
 anyhow = "1.0.95"
 clap = { version = "4.5.29", features = ["derive", "env"] }


### PR DESCRIPTION
This adds three jobs to the Release workflow: one to publish the crate to the crates.io registry, one to mint a new GitHub release, and a minor one to get the current version to be released.

With this, any new tags we push should start having releases generated for us. The GitHub release will show up as a draft for us to publish at our leisure, and the crate publish step will wait for approval from somebody else on the list of approvers.

There is currently a secret populated for the cargo registry token; the documentation I was able to find suggests that these tokens should be tied to an individual not an organization, so I’ve gone ahead and added a token to the secrets that has permissions to publish and yank versions of the aspect-reauth crate and no expiration. It seems like a good idea to add a couple other owners for the crate as well.