### PR TITLE
build workflow overhaul

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,44 +12,75 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
         include:
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            suffix: ""
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            suffix: ""
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            suffix: ".exe"
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            suffix: ""
+          - os: macos
+            arch: x86_64
+          - os: macos
+            arch: aarch64
+          - os: windows
+            arch: x86_64
+          - os: ubuntu
+            arch: x86_64
     steps:
+
+    - name: setup environment
+      shell: bash
+      run: |
+        set -u
+        osname() {
+          case $github_os in
+            macos) echo apple-darwin ;;
+            windows) echo pc-windows-msvc ;;
+            ubuntu) echo unknown-linux-gnu ;;
+            *) exit 1
+          esac
+        }
+        suffix=
+        if [[ windows = $github_os ]]; then
+          suffix=.exe
+        fi
+        retention_days=
+        if [[ pull_request = $event_name ]]; then
+          profile=fastbuild
+          retention_days=7
+        else
+          profile=release
+        fi
+
+        cat >>$GITHUB_ENV <<EOF
+        target=${arch}-$(osname)
+        suffix=$suffix
+        profile=$profile
+        retention_days=$retention_days
+        EOF
+      env:
+        arch: ${{ matrix.arch }}
+        github_os: ${{ matrix.os }}
+        event_name: ${{ github.event_name }}
+
     - run: sudo sh -c 'apt update && apt install libdbus-1-dev'
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu'
+
     - uses: stairwell-inc/checkout@v4
     - uses: stairwell-inc/cache@v4
       with:
         path: |
           ~/.cargo
           target
-        key: rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-
-          rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-
-          rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-
-    - run: rustup toolchain install ${{ env.RUSTC_VERSION }} --target ${{ matrix.target }} --profile minimal
+          rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-
+          rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-${{ hashFiles('**/Cargo.lock') }}-
+          rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-
+    - run: rustup toolchain install ${{ env.RUSTC_VERSION }} --target ${{ env.target }} --profile minimal
     - run: rustup default ${{ env.RUSTC_VERSION }}
-    - id: set-profile
-      run: echo profile=${{ github.event_name == 'pull_request' && 'fastbuild' || 'release' }} >> $GITHUB_OUTPUT
-      shell: bash
-    - run: cargo build --locked --profile ${{ steps.set-profile.outputs.profile }} --target ${{ matrix.target }}
+
+    - run: cargo build --locked --profile ${{ env.profile }} --target ${{ env.target }}
     - uses: stairwell-inc/upload-artifact@v4
       with:
-        name: aspect-reauth-${{ matrix.target }}
-        path: target/${{ matrix.target }}/${{ steps.set-profile.outputs.profile }}/aspect-reauth${{ matrix.suffix }}
-        retention-days: ${{ github.event_name == 'pull_request' && 7 || '' }}
+        name: aspect-reauth-${{ env.target }}
+        path: target/${{ env.target }}/${{ env.profile }}/aspect-reauth${{ env.suffix }}
+        retention-days: ${{ env.retention_days }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,15 +70,14 @@ jobs:
         path: |
           ~/.cargo
           target
-        key: rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-${{ env.profile }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-
-          rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-${{ hashFiles('**/Cargo.lock') }}-
-          rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-
+          rust-${{ env.RUSTC_VERSION }}-${{ env.target }}-${{ env.profile }}-
     - run: rustup toolchain install ${{ env.RUSTC_VERSION }} --target ${{ env.target }} --profile minimal
     - run: rustup default ${{ env.RUSTC_VERSION }}
 
     - run: cargo build --locked --profile ${{ env.profile }} --target ${{ env.target }}
+
     - uses: stairwell-inc/upload-artifact@v4
       with:
         name: aspect-reauth-${{ env.target }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: Build
 
+env:
+  RUSTC_VERSION: 1.86.0
+
 on:
   pull_request:
   push:
@@ -28,26 +31,25 @@ jobs:
     steps:
     - run: sudo sh -c 'apt update && apt install libdbus-1-dev'
       if: matrix.os == 'ubuntu-latest'
-    - run: |
-        rustup toolchain install stable --profile minimal || exit 1
-        rustup target add ${{ matrix.target }} || exit 1
     - uses: stairwell-inc/checkout@v4
     - uses: stairwell-inc/cache@v4
       with:
-        path: ~/.cargo
-        key: cargo-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
+        path: |
+          ~/.cargo
+          target
+        key: rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          cargo-${{ matrix.target }}-
-    - uses: stairwell-inc/cache@v4
-      with:
-        path: target
-        key: target-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-${{ github.ref }}
-        restore-keys: |
-          target-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-
-          target-${{ matrix.target }}-
-    - run: cargo build --locked --release --target ${{ matrix.target }}
+          rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}-
+          rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}-
+          rust-${{ env.RUSTC_VERSION }}-${{ matrix.target }}-
+    - run: rustup toolchain install ${{ env.RUSTC_VERSION }} --target ${{ matrix.target }} --profile minimal
+    - run: rustup default ${{ env.RUSTC_VERSION }}
+    - id: set-profile
+      run: echo profile=${{ github.event_name == 'pull_request' && 'fastbuild' || 'release' }} >> $GITHUB_OUTPUT
+      shell: bash
+    - run: cargo build --locked --profile ${{ steps.set-profile.outputs.profile }} --target ${{ matrix.target }}
     - uses: stairwell-inc/upload-artifact@v4
       with:
         name: aspect-reauth-${{ matrix.target }}
-        path: target/${{ matrix.target}}/release/aspect-reauth${{ matrix.suffix }}
+        path: target/${{ matrix.target }}/${{ steps.set-profile.outputs.profile }}/aspect-reauth${{ matrix.suffix }}
         retention-days: ${{ github.event_name == 'pull_request' && 7 || '' }}

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: stairwell-inc/checkout@v4
-    - run: rustup toolchain install stable
+    - run: rustup toolchain install stable && rustup default stable
     - run: cargo fmt -- --check

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: stairwell-inc/checkout@v4
-    - run: rustup update
+    - run: rustup toolchain install stable
     - run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ exclude = [
     ".gitignore",
 ]
 
+[profile.fastbuild]
+inherits = "dev"
+debug = "line-tables-only"
+
 [dependencies]
 anyhow = "1.0.95"
 clap = { version = "4.5.29", features = ["derive", "env"] }


### PR DESCRIPTION
Better caching: one cache only, cache key depends on Rust version. Pins the rust version used in the build workflow. [Swatinem/rust-cache](https://github.com/swatinem/rust-cache) needs the toolchain installation step to be done before the cache is loaded because it needs the toolchain step to decide on the cache key; by pinning a rustc version, we do not have that problem.

Builds pull requests with a new `fastbuild` profile, designed to act like Bazel’s `-c fastbuild`, i.e. no optimizations and minimal debug info. Pushes to main, and workflow calls for releases, still get built with `release`.

This also simplifies the build matrix, only specifying the non-redundant information (so the matrix job names in GitHub will be shorter) and computing the rest from that.

For the format workflow, I decided not to pin the Rust version; "stable" seems fine there.