### PR TITLE
Add a release step to publish to crates.io

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,11 @@ on:
   push:
     branches: ["main"]
   workflow_call:
+    inputs:
+      release:
+        default: false
+        type: boolean
+        description: "Whether we are building a release"
 
 jobs:
   build:
@@ -42,12 +47,12 @@ jobs:
         if [[ windows = $github_os ]]; then
           suffix=.exe
         fi
-        retention_days=
-        if [[ pull_request = $event_name ]]; then
+        if [[ true = "$release" ]]; then
+          profile=release
+          retention_days=90
+        else
           profile=fastbuild
           retention_days=7
-        else
-          profile=release
         fi
 
         cat >>$GITHUB_ENV <<EOF
@@ -59,7 +64,7 @@ jobs:
       env:
         arch: ${{ matrix.arch }}
         github_os: ${{ matrix.os }}
-        event_name: ${{ github.event_name }}
+        release: ${{ inputs.release }}
 
     - run: sudo sh -c 'apt update && apt install libdbus-1-dev'
       if: matrix.os == 'ubuntu'
@@ -84,4 +89,4 @@ jobs:
         retention-days: ${{ env.retention_days }}
 
     - run: cargo publish --locked --dry-run --target ${{ env.target }}
-      if: github.event_name == 'workflow_call'
+      if: inputs.release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,9 +77,11 @@ jobs:
     - run: rustup default ${{ env.RUSTC_VERSION }}
 
     - run: cargo build --locked --profile ${{ env.profile }} --target ${{ env.target }}
-
     - uses: stairwell-inc/upload-artifact@v4
       with:
         name: aspect-reauth-${{ env.target }}
         path: target/${{ env.target }}/${{ env.profile }}/aspect-reauth${{ env.suffix }}
         retention-days: ${{ env.retention_days }}
+
+    - run: cargo publish --locked --dry-run --target ${{ env.target }}
+      if: github.event_name == 'workflow_call'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,17 @@ jobs:
   build:
     uses: ./.github/workflows/build.yaml
 
+  publish:
+    name: Publish to crates.io
+    needs: build
+    runs-on: ubuntu-latest
+    environment: crates-io
+    steps:
+    - uses: stairwell-inc/checkout@v4
+    - run: cargo publish --no-verify --locked
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   macos-release:
     name: macOS Release
     needs: build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+    with:
+      release: true
 
   publish:
     name: Publish to crates.io


### PR DESCRIPTION
By publishing source-only releases on the [crates.io](https://crates.io) registry, we allow users to run e.g.:
```sh
env ASPECT_REMOTE=aw-remote-ext.mydomain.example cargo install aspect-reauth@0.7.0
```
and always get a build from the exact same aspect-reauth source code.

This modifies the build step to do a `cargo publish --dry-run` on each of the supported platforms to make sure that the package can build from the source we are about to upload. This only happens if the build is called via `workflow_call`, so in the release workflow. If these dry runs all succeed, then the release workflow itself then does the actual publish using the newly added `crates-io` environment.

The `crates-io` environment contains a secret for the cargo registry token; the documentation I was able to find online suggests that these tokens should be tied to an individual not an organization, so I’ve gone ahead and added a token with no expiration to the secrets that has permissions to publish and yank versions of the [aspect-reauth crate](https://crates.io/crates/aspect-reauth).

Presently this crate is owned by @bradharris-stairwell and I. If you should be on that list as well, please contact one of us.