### PR TITLE
Call the signed file `aspect-reauth`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,11 +42,9 @@ jobs:
         path: aspect-reauth-universal
 
     - run: |
-        cp aspect-reauth-universal .tmp.$$
-        trap "rm -f .tmp.$$" EXIT
-        codesign -s "Developer ID Application: Stairwell, Inc. (677UQVFGY8)" -f --timestamp -o runtime .tmp.$$
-        chmod +x .tmp.$$
-        mv .tmp.$$ aspect-reauth
+        cp aspect-reauth-universal aspect-reauth
+        codesign -s "Developer ID Application: Stairwell, Inc. (677UQVFGY8)" -f --timestamp -o runtime aspect-reauth
+        chmod +x aspect-reauth
 
     - name: Get version
       id: get-version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "aspect-reauth"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aspect-reauth"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Stairwell, Inc. <eng@stairwell.com>"]
 edition = "2021"
 homepage = "https://github.com/stairwell-inc/aspect-reauth"

--- a/src/ssh_mux/temp_socket.rs
+++ b/src/ssh_mux/temp_socket.rs
@@ -16,6 +16,7 @@
 use std::{ffi::OsStr, fs::remove_dir_all, path::Path};
 
 use anyhow::Result;
+use tempfile::TempDir;
 
 /// Exposes and controls a path suitable for use as a temporary socket. The path is made available
 /// by `AsRef<OsStr>` on `&TempSocket`, so that a reference to this may be passed directly to
@@ -37,13 +38,15 @@ impl TempSocket {
             use std::{fs::Permissions, os::unix::fs::PermissionsExt};
             builder.permissions(Permissions::from_mode(0o700));
         }
-        let dir = builder.prefix(prefix).tempdir()?;
+        Ok(Self::from_tempdir(builder.prefix(prefix).tempdir()?))
+    }
+
+    fn from_tempdir(dir: TempDir) -> Self {
         let mut path = dir.into_path();
-        // --- no early-return allowed from here ---
         path.push("sock");
-        Ok(TempSocket {
+        TempSocket {
             path: path.into_boxed_path(),
-        })
+        }
     }
 }
 


### PR DESCRIPTION
Apparently the name of the file that got signed gets embedded in the signature. Changing this to see if it helps with the duplicate password prompt issue.

Also reintroduces a non-exported `from_tempdir` function for clarity.