### PR TITLE
Transition to Trusted Publishing for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     environment: crates-io
     steps:
     - uses: stairwell-inc/checkout@v4
-    - uses: rust-lang/crates-io-auth-action@v1
+    - uses: stairwell-inc/crates-io-auth-action@v1
       id: auth
     - run: cargo publish --no-verify --locked
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,9 +18,11 @@ jobs:
     environment: crates-io
     steps:
     - uses: stairwell-inc/checkout@v4
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
     - run: cargo publish --no-verify --locked
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   macos-release:
     name: macOS Release


### PR DESCRIPTION
This removes the need for us to store a crates.io auth token, and also associates crate versions with the specific workflow that created them.

More info: https://crates.io/docs/trusted-publishing