### PR TITLE
Release v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "aspect-reauth"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aspect-reauth"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Stairwell, Inc. <eng@stairwell.com>"]
 edition = "2021"
 repository = "https://github.com/stairwell-inc/aspect-reauth"


### PR DESCRIPTION
Incorporates minor documentation fixes and workflow improvements; this should go in after #47, and so should get published to crates.io via Trusted Publishing.